### PR TITLE
Add accountboy.com to proxy rules

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -15,6 +15,7 @@
 ! https://github.com/gfwlist/gfwlist/issues/.
 
 !---------403/451/503/520 & URL Redirects---------
+||accountboy.com
 ||blogjav.net
 ||zoominfo.com
 ||ptwxz.com


### PR DESCRIPTION
Please add accountboy.com to proxy rules.

Domain:
accountboy.com

Expected behavior:
Traffic to accountboy.com and its subdomains should go through proxy.

Reason:
The domain is unreachable / unstable from mainland China without proxy, but works through proxy.