### PR TITLE
Add tokenplus.app

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -3719,6 +3719,7 @@ iipdigital.usembassy.gov
 ||token.im
 ||tokenlon.im
 ||tokenplus.app
+@@||*.tokenplus.app
 ||tardigrade.io
 ||torrentgalaxy.to
 ||tomp3.cc

--- a/list.txt
+++ b/list.txt
@@ -3718,6 +3718,7 @@ iipdigital.usembassy.gov
 ||textnow.com
 ||token.im
 ||tokenlon.im
+||tokenplus.app
 ||tardigrade.io
 ||torrentgalaxy.to
 ||tomp3.cc


### PR DESCRIPTION
`tokenplus.app` is blocked in mainland China.

Evidence:
- **DNS poisoning**: in-CN resolvers return `120.204.204.201` (China Mobile) instead of the real origin; that IP serves an unrelated self-signed cert (`CN=gitlab.xdevops.cn`), so browsers show `NET::ERR_CERT_AUTHORITY_INVALID`.
- **SNI-based TLS reset**: on the real origin IP, a ClientHello with `SNI=tokenplus.app` is RST, while `SNI=www.tokenplus.app` on the *same* IP completes with a valid Let's Encrypt cert — i.e. the block keys on the apex hostname itself.