### PR TITLE
Drop the subdomain exception for tokenplus.app (www is blocked too now)

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -3723,7 +3723,6 @@ iipdigital.usembassy.gov
 ||token.im
 ||tokenlon.im
 ||tokenplus.app
-@@||*.tokenplus.app
 ||tardigrade.io
 ||torrentgalaxy.to
 ||tomp3.cc


### PR DESCRIPTION
Follow-up to #2863. That PR added a whitelist carve-out for subdomains:

```
||tokenplus.app
@@||*.tokenplus.app
```

At the time that was correct — the block keyed on the apex hostname only, and `www.tokenplus.app` completed a normal TLS handshake. **That is no longer true.** The `@@` rule now forces `www.tokenplus.app` to go direct, straight into a TCP reset, so the current list actively breaks the site for users behind it. This PR removes that one line; `||tokenplus.app` already covers subdomains.

### Evidence (retested 2026-07-30, from mainland China, no proxy)

Same machine, same moment, same Vercel IP `64.29.17.65` — only the SNI changes:

| SNI | Result |
|---|---|
| *(none)* | valid Let's Encrypt cert, `CN=no-sni.vercel-infra.com` |
| `vercel.com` | valid Let's Encrypt cert, `CN=*.vercel.com` |
| `example.com` | clean TLS-level rejection (no cert, **no reset**) |
| `tokenplus.app` | **TCP reset** (`write:errno=54`) |
| `www.tokenplus.app` | **TCP reset** (`write:errno=54`) |
| `foo.tokenplus.app` | **TCP reset** (`write:errno=54`) |
| `cn.tokenplus.app` | **TCP reset** (`write:errno=54`) |

```
echo | openssl s_client -connect 64.29.17.65:443 -servername www.tokenplus.app
```

Reproduced 3/3, and again on a second Vercel IP `216.198.79.65`.

Two things worth noting:

- `foo.` and `cn.` **do not exist in DNS at all** and are still reset, so the filter matches the `tokenplus.app` suffix rather than any specific record. No subdomain will be reachable.
- The unrelated-SNI and no-SNI rows rule out an IP-level block, and the `example.com` row shows what a non-reset rejection looks like on the same endpoint for comparison.

Reachability from outside is unaffected — through a proxy, both `tokenplus.app` and `www.tokenplus.app` return valid Let's Encrypt certs on those same IPs, so the origin is healthy and this is purely in-path.

Plain HTTP is intercepted as well: a port-80 request with `Host: www.tokenplus.app` returns `Server: JSP2/1.0.26` and `Location: http://127.0.0.1`.

I maintain this domain, so I can retest on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)